### PR TITLE
Refactor

### DIFF
--- a/lib/rapido/controller.rb
+++ b/lib/rapido/controller.rb
@@ -32,7 +32,7 @@ module Rapido
 
       def owner_lookup_param(*args)
         return @owner_lookup_param = str.to_sym if args.count == 1
-        @owner_lookup_param = args.join("_").to_sym
+        @owner_lookup_param = args.join('_').to_sym
       end
 
       def owner_lookup_field(str)

--- a/test/test_5_1/app/controllers/api/hydrospanners_controller.rb
+++ b/test/test_5_1/app/controllers/api/hydrospanners_controller.rb
@@ -2,9 +2,7 @@ class Api::HydrospannersController < Api::ApplicationController
   include Rapido::Controller
   include Rapido::ApiController
 
-  owner_class :toolbox
-  owner_lookup_param :toolbox_name
-  owner_lookup_field :name
+  belongs_to :toolbox, foreign_key: :name
   lookup_param :name
   attr_permitted :name
 end

--- a/test/test_5_1/app/controllers/api/messages_controller.rb
+++ b/test/test_5_1/app/controllers/api/messages_controller.rb
@@ -2,10 +2,7 @@ class Api::MessagesController < ActionController::API
   include Rapido::Controller
   include Rapido::ApiController
 
-  owner_class :comlink
-  owner_lookup_param :comlink_token
-  owner_lookup_field :token
-
+  belongs_to :comlink, foreign_key: :token
   free_from_authority!
   permit_all_params!
 end

--- a/test/test_5_1/app/controllers/api/toolboxes_controller.rb
+++ b/test/test_5_1/app/controllers/api/toolboxes_controller.rb
@@ -2,13 +2,7 @@ class Api::ToolboxesController < Api::ApplicationController
   include Rapido::Controller
   include Rapido::ApiController
 
-  owner_class :account
+  belongs_to :account, getter: :authority
   lookup_param :name
   attr_permitted :name
-
-  private
-
-  def owner
-    @authority
-  end
 end

--- a/test/test_5_1/app/controllers/hydrospanners_controller.rb
+++ b/test/test_5_1/app/controllers/hydrospanners_controller.rb
@@ -1,16 +1,14 @@
 class HydrospannersController < ApplicationController
   include Rapido::AppViews
 
+  belongs_to :toolbox, foreign_key: :name
   attr_permitted :name
   lookup_param :name
-
-  owner_class :toolbox
-  owner_lookup_param :toolbox_name
-  owner_lookup_field :name
+  authority :current_user_account
 
   private
 
-  def authority
+  def current_user_account
     current_user.account
   end
 end

--- a/test/test_5_1/app/controllers/toolboxes_controller.rb
+++ b/test/test_5_1/app/controllers/toolboxes_controller.rb
@@ -1,13 +1,13 @@
 class ToolboxesController < ApplicationController
   before_action :authenticate_user!
 
+  belongs_to :account, getter: :current_user_account
   attr_permitted :name
   lookup_param :name
 
-  owner_class :account
+  private
 
-
-  def owner
+  def current_user_account
     current_user.account
   end
 end


### PR DESCRIPTION
# Changelog

* Swapped out `owner_class` for `belongs_to`, which now takes 3 optional arguments - `foreign_key` (previously `owner_lookup_field`), `foreign_key_param` (previously `owner_lookup_param`) and `getter` (which allows you to specify a method to call to retrieve the owner rather than overriding `owner` directly.