### PR TITLE
Attempt superclass authority if nil

### DIFF
--- a/lib/rapido/controller.rb
+++ b/lib/rapido/controller.rb
@@ -67,7 +67,8 @@ module Rapido
           if setting(:free_from_authority)
             nil
           else
-            send(setting(:authority_getter))
+            send(setting(:authority_getter) ||
+              self.class.superclass.instance_variable_get(:@authority_getter))
           end
         end
       end

--- a/test/test_5_1/Gemfile.lock
+++ b/test/test_5_1/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: ../..
   specs:
-    rails-rapido (0.3.1)
+    rails-rapido (0.3.2)
       kaminari (~> 1.1)
 
 GEM

--- a/test/test_5_1/app/controllers/application_controller.rb
+++ b/test/test_5_1/app/controllers/application_controller.rb
@@ -6,4 +6,12 @@ class ApplicationController < ActionController::Base
   include Rapido::Controller
   include Rapido::AppController
   include Rapido::AppRecordNotFound
+
+  authority :current_user_account
+
+  private
+
+  def current_user_account
+    current_user.account
+  end
 end

--- a/test/test_5_1/app/controllers/hydrospanners_controller.rb
+++ b/test/test_5_1/app/controllers/hydrospanners_controller.rb
@@ -4,11 +4,4 @@ class HydrospannersController < ApplicationController
   belongs_to :toolbox, foreign_key: :name
   attr_permitted :name
   lookup_param :name
-  authority :current_user_account
-
-  private
-
-  def current_user_account
-    current_user.account
-  end
 end

--- a/test/test_5_1/app/controllers/toolboxes_controller.rb
+++ b/test/test_5_1/app/controllers/toolboxes_controller.rb
@@ -4,10 +4,4 @@ class ToolboxesController < ApplicationController
   belongs_to :account, getter: :current_user_account
   attr_permitted :name
   lookup_param :name
-
-  private
-
-  def current_user_account
-    current_user.account
-  end
 end


### PR DESCRIPTION
# Changelog

* `authority` setting in superclass was ignored if present. Very common to use controller superclass, like `application_controller`, to govern authority.