### PR TITLE
Replacing new with build

### DIFF
--- a/lib/rapido/app_controller.rb
+++ b/lib/rapido/app_controller.rb
@@ -23,7 +23,7 @@ module Rapido
     end
 
     def new
-      @resource = resource_base.send(resource_class_name.pluralize).new
+      @resource = resource_base.send(resource_class_name.pluralize).build
     end
 
     def create

--- a/lib/rapido/controller.rb
+++ b/lib/rapido/controller.rb
@@ -122,7 +122,7 @@ module Rapido
       end
 
       def build_resource
-        resource_base.send(resource_class_name.pluralize).new(resource_params)
+        resource_base.send(resource_class_name.pluralize).build(resource_params)
       end
 
       def resource_collection

--- a/test/test_5_1/Gemfile.lock
+++ b/test/test_5_1/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: ../..
   specs:
-    rails-rapido (0.3.3)
+    rails-rapido (0.3.4)
       kaminari (~> 1.1)
 
 GEM


### PR DESCRIPTION
# Changelog

* Replace use of ActiveRecord `new` with `build` - benign change, but allows for easier use of non-database backed models.