### PR TITLE
After create success callback

### DIFF
--- a/lib/rapido/app_controller.rb
+++ b/lib/rapido/app_controller.rb
@@ -29,6 +29,7 @@ module Rapido
     def create
       new_resource = build_resource
       if new_resource.save
+        after_create_success(new_resource)
         redirect_to after_create_path(new_resource)
       else
         flash[:error] = new_resource.errors.full_messages.join('. ')
@@ -59,6 +60,9 @@ module Rapido
     end
 
     private
+
+    def after_create_success(*)
+    end
 
     def resource_path(action, resource = nil)
       keys = { controller: params[:controller], action: action }

--- a/test/test_5_1/Gemfile
+++ b/test/test_5_1/Gemfile
@@ -22,8 +22,8 @@ group :development, :test do
   gem 'cucumber-rails', require: false
   gem 'cucumber-api-steps', github: 'jayzes/cucumber-api-steps'
   gem 'cucumber-persona'
+  gem 'cucumber-sammies'
   gem 'cucumber_priority'
   gem 'database_cleaner'
-  gem 'spreewald', github: 'makandra/spreewald'
   gem 'rspec-rails'
 end

--- a/test/test_5_1/Gemfile.lock
+++ b/test/test_5_1/Gemfile.lock
@@ -6,14 +6,6 @@ GIT
       cucumber (>= 2.0.2)
       jsonpath (>= 0.1.2)
 
-GIT
-  remote: https://github.com/makandra/spreewald.git
-  revision: 44d6d8241c6c516a7a3ba5f70e8e21818b89077e
-  specs:
-    spreewald (1.10.0)
-      cucumber
-      cucumber_priority
-
 PATH
   remote: ../..
   specs:
@@ -93,6 +85,7 @@ GEM
       mime-types (>= 1.17, < 4)
       nokogiri (~> 1.5)
       railties (>= 4, < 5.2)
+    cucumber-sammies (0.1.2)
     cucumber-wire (0.0.1)
     cucumber_priority (0.2.0)
       cucumber
@@ -237,6 +230,7 @@ DEPENDENCIES
   cucumber-api-steps!
   cucumber-persona
   cucumber-rails
+  cucumber-sammies
   cucumber_priority
   database_cleaner
   devise
@@ -248,9 +242,8 @@ DEPENDENCIES
   rspec-rails
   simple_form
   slim
-  spreewald!
   sqlite3
   turbolinks
 
 BUNDLED WITH
-   1.14.6
+   1.16.1

--- a/test/test_5_1/app/controllers/hydrospanners_controller.rb
+++ b/test/test_5_1/app/controllers/hydrospanners_controller.rb
@@ -4,4 +4,10 @@ class HydrospannersController < ApplicationController
   belongs_to :toolbox, foreign_key: :name
   attr_permitted :name
   lookup_param :name
+
+  private
+
+  def after_create_success(*)
+    flash[:success] = flash[:success].to_s + "Well done!"
+  end
 end

--- a/test/test_5_1/features/hydrospanners.feature
+++ b/test/test_5_1/features/hydrospanners.feature
@@ -13,12 +13,13 @@ Feature: Hydrospanners
     When I follow "View Hydrospanners"
     And I should see "mediocrehydrospanner"
 
-  Scenario: User can create a new hydrospanner for a toolbox
+  Scenario: User can create a new hydrospanner for a toolbox and apply an after success filter
     When I follow "View Hydrospanners"
     And I follow "New Hydrospanner"
     And I fill in "Name" with "BetterHydrospanner"
     And I press "Save"
     Then I should see "BetterHydrospanner"
+    And I should see "Well done!"
 
   Scenario: User can view hydrospanner
     When I follow "View Hydrospanners"

--- a/test/test_5_1/features/support/env.rb
+++ b/test/test_5_1/features/support/env.rb
@@ -1,7 +1,9 @@
 require 'cucumber/rails'
 require 'rspec/matchers'
 require 'cucumber/api_steps'
-require 'spreewald/all_steps'
+require 'cucumber/sammies/step_definitions/content_steps'
+require 'cucumber/sammies/step_definitions/navigation_steps'
+require 'cucumber/sammies/step_definitions/form_steps'
 
 ActionController::Base.allow_rescue = false
 


### PR DESCRIPTION
# Changelog

* AppController now has an overrideable `after_create_success` callback that executes if creation is successful but before redirect.