### PR TITLE
After create callback improvements

### DIFF
--- a/lib/rapido/app_controller.rb
+++ b/lib/rapido/app_controller.rb
@@ -30,10 +30,11 @@ module Rapido
       new_resource = build_resource
       if new_resource.save
         after_create_success(new_resource)
-        redirect_to after_create_path(new_resource)
+        redirect_to after_create_path(new_resource) unless performed?
       else
         flash[:error] = new_resource.errors.full_messages.join('. ')
-        redirect_to new_path
+        after_create_failure(new_resource)
+        redirect_to new_path unless performed?
       end
     end
 
@@ -62,6 +63,9 @@ module Rapido
     private
 
     def after_create_success(*)
+    end
+
+    def after_create_failure(*)
     end
 
     def resource_path(action, resource = nil)

--- a/test/test_5_1/app/controllers/hydrospanners_controller.rb
+++ b/test/test_5_1/app/controllers/hydrospanners_controller.rb
@@ -7,7 +7,11 @@ class HydrospannersController < ApplicationController
 
   private
 
-  def after_create_success(*)
-    flash[:success] = flash[:success].to_s + "Well done!"
+  def after_create_success(hydrospanner)
+    render plain: "Rendered text: " + hydrospanner.name
+  end
+
+  def after_create_failure(*)
+    render plain: "Rendered text: " + flash[:error]
   end
 end

--- a/test/test_5_1/features/hydrospanners.feature
+++ b/test/test_5_1/features/hydrospanners.feature
@@ -18,8 +18,14 @@ Feature: Hydrospanners
     And I follow "New Hydrospanner"
     And I fill in "Name" with "BetterHydrospanner"
     And I press "Save"
-    Then I should see "BetterHydrospanner"
-    And I should see "Well done!"
+    Then I should see "Rendered text: BetterHydrospanner"
+
+  Scenario: System prevents invalid create
+    When I follow "View Hydrospanners"
+    When I follow "New Hydrospanner"
+    And I fill in "Name" with ""
+    And I press "Save"
+    Then I should see "Rendered text: Name can't be blank"
 
   Scenario: User can view hydrospanner
     When I follow "View Hydrospanners"
@@ -42,7 +48,7 @@ Feature: Hydrospanners
     And I press "Save"
     Then I should see "Name can't be blank"
 
-  Scenario: User cand delete a hydrospanner
+  Scenario: User can delete a hydrospanner
     When I follow "View Hydrospanners"
     And I follow "mediocrehydrospanner"
     When I click on "Delete"


### PR DESCRIPTION
# Changelog

* The AppController `after_create_success` now has a `after_create_failure` counterpart. Both are called immediately before redirect, which now checks for a performed, so the redirect can be pre-empted.