### PR TITLE
Adding after_update_success and after_update_failure filters to app_controller

### DIFF
--- a/lib/rapido/app_controller.rb
+++ b/lib/rapido/app_controller.rb
@@ -52,11 +52,13 @@ module Rapido
     def update
       resource.assign_attributes(resource_params)
       if resource.save
-        redirect_to after_update_path(resource)
+        after_update_success(resource)
+        redirect_to after_update_path(resource) unless performed?
       else
         flash[:error] = resource.errors.full_messages.join('. ')
         resource.reload
-        redirect_to edit_path(resource)
+        after_update_failure(resource)
+        redirect_to edit_path(resource) unless performed?
       end
     end
 
@@ -66,6 +68,12 @@ module Rapido
     end
 
     def after_create_failure(*)
+    end
+
+    def after_update_success(*)
+    end
+
+    def after_update_failure(*)
     end
 
     def resource_path(action, resource = nil)

--- a/lib/rapido/version.rb
+++ b/lib/rapido/version.rb
@@ -1,3 +1,3 @@
 module Rapido
-  VERSION = '0.3.7'
+  VERSION = '0.3.8'
 end

--- a/test/test_5_1/Gemfile.lock
+++ b/test/test_5_1/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ../..
   specs:
-    rails-rapido (0.3.6)
+    rails-rapido (0.3.8)
       kaminari (~> 1.1)
 
 GEM

--- a/test/test_5_1/app/controllers/protocol_droids_controller.rb
+++ b/test/test_5_1/app/controllers/protocol_droids_controller.rb
@@ -15,4 +15,12 @@ class User::ProtocolDroidsController < ApplicationController
   def after_create_path(protocol_droid)
     user_protocol_droid_path(protocol_droid)
   end
+
+  def after_update_success(protocol_droid)
+    render plain: "Success! You've updated #{protocol_droid.name}"
+  end
+
+  def after_update_failure(protocol_droid)
+    render plain: "Blast it! You've failed to update #{protocol_droid.name}"
+  end
 end

--- a/test/test_5_1/features/protocol_droids.feature
+++ b/test/test_5_1/features/protocol_droids.feature
@@ -1,4 +1,4 @@
-Feature: Toolboxes
+Feature: Protocol droids - demonstrating has_one relationship support
 
   Background:
     Given I am Ben Franklin
@@ -19,7 +19,7 @@ Feature: Toolboxes
     And I press "Save"
     Then I should see "Name can't be blank"
 
-  Scenario: User can edit and update a toolbox
+  Scenario: after_update_success filter
     When I visit "/user/protocol_droids/new"
     And I fill in "Name" with "GreatDroid"
     And I press "Save"
@@ -27,4 +27,14 @@ Feature: Toolboxes
     And I click on "Edit"
     And I fill in "Name" with "SlightlyBetterDroid"
     And I press "Save"
-    Then I should see "SlightlyBetterDroid"
+    Then the page body should include "Success! You've updated SlightlyBetterDroid"
+
+  Scenario: after_update_failure filter
+    When I visit "/user/protocol_droids/new"
+    And I fill in "Name" with "GreatDroid"
+    And I press "Save"
+    And I visit "/user/protocol_droids/GreatDroid"
+    And I click on "Edit"
+    And I fill in "Name" with ""
+    And I press "Save"
+    Then the page body should include "Blast it! You've failed to update GreatDroid"


### PR DESCRIPTION
# Changelog

* Added `after_update_success` and `after_update_failure` filters to app_controller.