### PR TITLE
Removing unused Kaminari dependency

### DIFF
--- a/lib/rapido/controller.rb
+++ b/lib/rapido/controller.rb
@@ -193,7 +193,7 @@ module Rapido
           if setting(:has_one)
             owner.send(resource_class_name)
           else
-            owner.send(resource_class_name.pluralize).page(params[:page])
+            owner.send(resource_class_name.pluralize)
           end
         end
       end

--- a/rapido.gemspec
+++ b/rapido.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'kaminari', '~> 1.1'
   spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'
 end

--- a/test/test_5_1/Gemfile.lock
+++ b/test/test_5_1/Gemfile.lock
@@ -10,7 +10,6 @@ PATH
   remote: ../..
   specs:
     rails-rapido (0.5.0)
-      kaminari (~> 1.1)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
# Changelog

* Removed unnecessary use of Kaminari. No longer needed with Presenters.